### PR TITLE
:duct.core/environment has been removed

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ To install, add the following to your project `:dependencies`:
 To add this module to your configuration, add a reference to `:duct.module/pedestal` (and `:duct.server/pedestal` if necessary):
 
 ```edn
-{:duct.profile/base
+{:duct.profile/dev
+ :duct.profile/base
  {:duct.core/project-ns some-api
-  :duct.core/environment :production
 
   :duct.server/pedestal
   {:service #:io.pedestal.http{:routes #ig/ref :some-api.routes/routes

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ To install, add the following to your project `:dependencies`:
 To add this module to your configuration, add a reference to `:duct.module/pedestal` (and `:duct.server/pedestal` if necessary):
 
 ```edn
-{:duct.profile/dev
+{:duct.profile/dev {}
  :duct.profile/base
  {:duct.core/project-ns some-api
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,20 @@
+{:deps { ;; Duct
+        duct/core {:mvn/version "0.7.0"}
+
+        ;; Pedestal
+        io.pedestal/pedestal.service {:mvn/version "0.5.5"}
+
+        ;; Pedestal server adapter
+        ;; Remove this line and uncomment one of the next lines to
+        ;; use Immutant or Tomcat instead of Jetty:
+        io.pedestal/pedestal.jetty {:mvn/version "0.5.5"}
+        ;; [io.pedestal/pedestal.immutant "0.5.5"]
+        ;; [io.pedestal/pedestal.tomcat "0.5.5"]
+
+        ;; logging
+        ch.qos.logback/logback-classic {:mvn/version "1.2.3"
+                                        :exclusions [org.slf4j/slf4j-api]}
+        org.slf4j/jcl-over-slf4j {:mvn/version "1.7.25"}
+        org.slf4j/jul-to-slf4j {:mvn/version "1.7.25"}
+        org.slf4j/log4j-over-slf4j {:mvn/version "1.7.25"}}
+ :paths ["src"]}

--- a/test/duct/module/pedestal_test.clj
+++ b/test/duct/module/pedestal_test.clj
@@ -9,8 +9,7 @@
   (t/testing "environment: production"
     (t/testing "no options"
       (let [config {:duct.profile/base
-                    {:duct.core/project-ns 'some-api
-                     :duct.core/environment :production}
+                    {:duct.core/project-ns 'some-api}
                     :duct.profile/prod {}
                     :duct.module/pedestal {}}]
         (t/is (= {:duct.core/project-ns 'some-api
@@ -25,7 +24,6 @@
                                            :port 8888}
             config {:duct.profile/base
                     {:duct.core/project-ns 'some-api
-                     :duct.core/environment :production
                      :duct.server/pedestal {:service service-map}}
                     :duct.profile/prod {}
                     :duct.module/pedestal {:default? false
@@ -40,9 +38,9 @@
                  (duct/prep-config config))))))
   (t/testing "environment: development"
     (t/testing "no options"
-      (let [config {:duct.profile/base
-                    {:duct.core/project-ns 'some-api
-                     :duct.core/environment :development}
+      (let [config {:duct.profile/dev {}
+                    :duct.profile/base
+                    {:duct.core/project-ns 'some-api}
                     :duct.module/pedestal {}}]
         (t/is (= {:duct.core/project-ns 'some-api
                   :duct.core/environment :development
@@ -50,13 +48,13 @@
                   {:base-service sut/dev-service
                    :default? true
                    :dev? true}}
-                 (duct/prep-config config)))))
+                 (duct/prep-config config [:duct.profile/dev])))))
     (t/testing "options specified"
       (let [service-map #:io.pedestal.http{:routes #{}
                                            :port 8888}
-            config {:duct.profile/base
+            config {:duct.profile/dev {}
+                    :duct.profile/base
                     {:duct.core/project-ns 'some-api
-                     :duct.core/environment :development
                      :duct.server/pedestal {:service service-map}}
                     :duct.module/pedestal {:default? false
                                            :dev? false}}]

--- a/test/duct/server/pedestal_test.clj
+++ b/test/duct/server/pedestal_test.clj
@@ -35,9 +35,9 @@
          (ig/halt! ~bound-var)))))
 
 (t/deftest server-test
-  (let [config {:duct.profile/base
+  (let [config {:duct.profile/dev {}
+                :duct.profile/base
                 {:duct.core/project-ns 'some-api
-                 :duct.core/environment :development
                  :duct.server/pedestal {:service service-map}}
                 :duct.module/pedestal {}}]
     (with-system [sys (duct/prep-config config)]


### PR DESCRIPTION
c.f. https://github.com/duct-framework/duct/blob/master/UPGRADING.md

So I think we should avoid telling people to use :duct.core/environment in their config.

I also added a deps.edn to make consumption easier for some peopel.