### PR TITLE
Update dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,8 +41,8 @@ jobs:
           name: Install static code analysis tools
           environment:
             CLJSTYLE_VERSION: 0.15.0
-            CLJ_KONDO_VERSION: 2021.04.23
-            JOKER_VERSION: 0.17.1
+            CLJ_KONDO_VERSION: 2021.12.01
+            JOKER_VERSION: 0.17.3
           command: |
             # cljstyle
             wget https://github.com/greglook/cljstyle/releases/download/${CLJSTYLE_VERSION}/cljstyle_${CLJSTYLE_VERSION}_linux.tar.gz

--- a/deps.edn
+++ b/deps.edn
@@ -12,9 +12,9 @@
         ;; [io.pedestal/pedestal.tomcat "0.5.9"]
 
         ;; logging
-        ch.qos.logback/logback-classic {:mvn/version "1.2.3"
+        ch.qos.logback/logback-classic {:mvn/version "1.2.8"
                                         :exclusions [org.slf4j/slf4j-api]}
-        org.slf4j/jcl-over-slf4j {:mvn/version "1.7.30"}
-        org.slf4j/jul-to-slf4j {:mvn/version "1.7.30"}
-        org.slf4j/log4j-over-slf4j {:mvn/version "1.7.30"}}
+        org.slf4j/jcl-over-slf4j {:mvn/version "1.7.32"}
+        org.slf4j/jul-to-slf4j {:mvn/version "1.7.32"}
+        org.slf4j/log4j-over-slf4j {:mvn/version "1.7.32"}}
  :paths ["src"]}

--- a/project.clj
+++ b/project.clj
@@ -18,10 +18,10 @@
                  ;; [io.pedestal/pedestal.tomcat "0.5.9"]
 
                  ;; logging
-                 [ch.qos.logback/logback-classic "1.2.3" :exclusions [org.slf4j/slf4j-api]]
-                 [org.slf4j/jcl-over-slf4j "1.7.30"]
-                 [org.slf4j/jul-to-slf4j "1.7.30"]
-                 [org.slf4j/log4j-over-slf4j "1.7.30"]]
+                 [ch.qos.logback/logback-classic "1.2.8" :exclusions [org.slf4j/slf4j-api]]
+                 [org.slf4j/jcl-over-slf4j "1.7.32"]
+                 [org.slf4j/jul-to-slf4j "1.7.32"]
+                 [org.slf4j/log4j-over-slf4j "1.7.32"]]
   :deploy-repositories [["releases" :clojars]]
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.10.3"]
                                   [pjstadig/humane-test-output "0.11.0"]]


### PR DESCRIPTION
- [Logback 1.2.8](http://logback.qos.ch/news.html)
    - 14th of December, 2021, Release of version 1.2.8